### PR TITLE
linker: Restore optional platform text relocations use

### DIFF
--- a/linker/Android.mk
+++ b/linker/Android.mk
@@ -54,7 +54,9 @@ ifeq ($(TARGET_IS_64_BIT),true)
 LOCAL_CPPFLAGS += -DTARGET_IS_64_BIT
 endif
 
+ifeq ($(TARGET_NEEDS_PLATFORM_TEXT_RELOCATIONS),true)
 LOCAL_CPPFLAGS += -DTARGET_NEEDS_PLATFORM_TEXT_RELOCATIONS
+endif
 
 # We need to access Bionic private headers in the linker.
 LOCAL_CFLAGS += -I$(LOCAL_PATH)/../libc/


### PR DESCRIPTION
 * TARGET_NEEDS_PLATFORM_TEXT_RELOCATIONS was introduced
    in commit I994ab1a600a0b237b496ceebe2dd54febc28a6bd
    but lost during changes to allow user builds too
    in commit I92fadb191d74ccaede175715e9bd42650857ae88

Change-Id: Ia891988203f4025f798c31b14a001670d5916401